### PR TITLE
Remove old repo cache for binaryn3xus

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -168,12 +168,6 @@
     5
   ],
   [
-    "JoshuaGarrison27/HomeOps",
-    "https://github.com/JoshuaGarrison27/HomeOps",
-    "main",
-    9
-  ],
-  [
     "LilDrunkenSmurf/k3s-home-cluster",
     "https://github.com/LilDrunkenSmurf/k3s-home-cluster",
     "main",


### PR DESCRIPTION
This PR removes my old username from the `repos.json` file