### PR TITLE
fix(download.py): resolve fatal clone errors

### DIFF
--- a/download.py
+++ b/download.py
@@ -22,9 +22,8 @@ subprocess.run(['mkdir', 'repos'])
 for repo in repos:
   dir_name, branch, url = repo
   print("downloading "+dir_name+" "+branch+" "+url)
-  bash_command('rm -rf repos/'+dir_name)
   # max 1 year
-  bash_command('git clone '+url+' repos/'+dir_name+' --branch '+branch+' --filter=blob:limit=1m --single-branch --shallow-since="1 year"')
+  bash_command(f'rm -rf repos/{dir_name}; git clone {url} repos/{dir_name} --branch {branch} --filter=blob:limit=1m --single-branch --shallow-since="1 year"')
 
 print('')
 print('')


### PR DESCRIPTION


## Issue Description

If there is an existing repo checkout, the `rm` command is executed asynchronously right before the `git clone` command, which results in errors such as these:

```
Cloning into 'repos/0dragosh-homelab'...
fatal: destination path 'repos/1Solon-Home-Server-Configuration' already exists and is not an empty directory.
fatal: destination path 'repos/3nm1-home-ops' already exists and is not an empty directory.
fatal: destination path 'repos/Alexsaphir-K3s-Flux' already exists and is not an empty directory.
fatal: destination path 'repos/AndersBallegaard-homelab-k8s' already exists and is not an empty directory.
fatal: destination path 'repos/AnthonyEnr1quez-k3s-gitops' already exists and is not an empty directory.
fatal: destination path 'repos/Bchast93-thousand-sunny' already exists and is not an empty directory.
fatal: destination path 'repos/BehnH-fleet' already exists and is not an empty directory.
Cloning into 'repos/BehnH-infra'...
fatal: destination path 'repos/BeryJu-k8s' already exists and is not an empty directory.
Cloning into 'repos/Bibz87-kubernetes-example'...
[..]
```

You can also see the out-of-order execution in a recent CI run [here](https://github.com/whazor/k8s-at-home-search/actions/runs/14720650277/job/41313715918#step:9:433).

## Proposed fix

This change makes sure the repo folder deletion completes before attempting a `git clone`. This resolves the fatal clone errors related to partially executed `rm` invocations.

This is done by bringing the `rm -rf` within the same subprocess invocation, right before `git clone`.

## Other Changes

Cleaned up the command a bit by using an f-string, rather than concatenating the string and variables.

### Comments

There are other issues I observed by looking at the Github Actions output, some of those might be related to the `--shallow-since` argument.
It also seems that the `--filter=blob:limit=1m` is not having the intended effect in same cases, as there are 60MB binaries being downloaded into the `repos/` folder.