### PR TITLE
fix(search.py): continue on `ValueError` when parsing repositories

### DIFF
--- a/search.py
+++ b/search.py
@@ -116,6 +116,8 @@ for root, dirs, files in os.walk("repos/"):
                     s.insert(c1, c2, result)
                   except ValidationError as e:
                     print("validation error", e)
+                  except ValueError as e:
+                    print("value error", e)
           except YAMLError as exc:
             print("yaml err")
             print(exc)


### PR DESCRIPTION
Simple fix to handle parsing repositories with circular anchor references in their yaml, which raises the `ValueError` exception. Just skip this repository and move on to the next.

See this failing run: https://github.com/whazor/k8s-at-home-search/actions/runs/15646405146/job/44084610473#step:10:215 that has been blocking updating of https://kubesearch.dev/ for 3 weeks, as of this message.

Full exception
```sh
$ uv run search.py
[....]
found duplicate anchor; first occurrence
  in "repos/mapanare-labs-mapanarenet-home-ops/kubernetes/apps/collaboration/plane/app/helmrelease.yaml", line 38, column 22
second occurrence
  in "repos/mapanare-labs-mapanarenet-home-ops/kubernetes/apps/collaboration/plane/app/helmrelease.yaml", line 89, column 22
yaml err
found duplicate anchor; first occurrence
  in "repos/mapanare-labs-mapanarenet-home-ops/kubernetes/apps/collaboration/twenty/app/helmrelease.yaml", line 38, column 22
second occurrence
  in "repos/mapanare-labs-mapanarenet-home-ops/kubernetes/apps/collaboration/twenty/app/helmrelease.yaml", line 89, column 22
Traceback (most recent call last):
  File "/home/runner/work/k8s-at-home-search/k8s-at-home-search/search.py", line 115, in <module>
    result = s.parse(prepare_walk(doc), rest)
  File "/home/runner/work/k8s-at-home-search/k8s-at-home-search/scanners/flux_helm_release.py", line 80, in parse
    'values': json.dumps(values, default=str)
              ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.4/x64/lib/python3.13/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ~~~~~~^^^^^
  File "/opt/hostedtoolcache/Python/3.13.4/x64/lib/python3.13/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/hostedtoolcache/Python/3.13.4/x64/lib/python3.13/json/encoder.py", line 261, in iterencode
    return _iterencode(o, 0)
ValueError: Circular reference detected
Error: Process completed with exit code 1.
```

Running this branch locally, I successfully finish

```sh
$ uv run search.py
[....]
while scanning a plain scalar
  in "repos/tholinka-home-ops/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml", line 61, column 21
found unexpected ':'
  in "repos/tholinka-home-ops/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml", line 61, column 23
yaml err
found duplicate anchor; first occurrence
  in "repos/samip5-k8s-cluster/k8s/nebula/apps/default/your_spotify/app/hr.yaml", line 74, column 25
second occurrence
  in "repos/samip5-k8s-cluster/k8s/nebula/apps/default/your_spotify/app/hr.yaml", line 115, column 21
yaml err
while scanning a plain scalar
  in "repos/thaynes43-haynes-ops/kubernetes/apps/ai/open-webui/app/helmrelease.yaml", line 26, column 18
found unexpected ':'
  in "repos/thaynes43-haynes-ops/kubernetes/apps/ai/open-webui/app/helmrelease.yaml", line 26, column 22
flux_helm_release count 13504
argo_helm_application count 103
flux_oci_repository count 1770

```